### PR TITLE
Fix ocamlobjinfo for flambda (#809)

### DIFF
--- a/asmcomp/export_info.ml
+++ b/asmcomp/export_info.ml
@@ -224,7 +224,7 @@ let nest_eid_map map =
   in
   Export_id.Map.fold add_map map Compilation_unit.Map.empty
 
-let print_approx ppf (t : t) =
+let print_approx ppf ((t,root_symbols) : t * Symbol.t list) =
   let values = t.values in
   let fprintf = Format.fprintf in
   let printed = ref Export_id.Set.empty in
@@ -329,6 +329,7 @@ let print_approx ppf (t : t) =
       print_recorded_symbols ();
     end
   in
+  List.iter (fun s -> Queue.push s symbols_to_print) root_symbols;
   fprintf ppf "@[<hov 2>Globals:@ ";
   fprintf ppf "@]@ @[<hov 2>Symbols:@ ";
   print_recorded_symbols ();
@@ -345,10 +346,13 @@ let print_offsets ppf (t : t) =
         Var_within_closure.print vid off) t.offset_fv;
   Format.fprintf ppf "@]@ "
 
-let print_all ppf (t : t) =
+let print_functions ppf (t : t) =
+  Set_of_closures_id.Map.print Flambda.print_function_declarations ppf
+    t.sets_of_closures
+
+let print_all ppf ((t, root_symbols) : t * Symbol.t list) =
   let fprintf = Format.fprintf in
   fprintf ppf "approxs@ %a@.@."
-    print_approx t;
+    print_approx (t, root_symbols);
   fprintf ppf "functions@ %a@.@."
-    (Set_of_closures_id.Map.print Flambda.print_function_declarations)
-    t.sets_of_closures
+    print_functions t

--- a/asmcomp/export_info.mli
+++ b/asmcomp/export_info.mli
@@ -143,6 +143,7 @@ val nest_eid_map
 
 (**/**)
 (* Debug printing functions. *)
-val print_approx : Format.formatter -> t -> unit
+val print_approx : Format.formatter -> t * Symbol.t list -> unit
+val print_functions : Format.formatter -> t -> unit
 val print_offsets : Format.formatter -> t -> unit
-val print_all : Format.formatter -> t -> unit
+val print_all : Format.formatter -> t * Symbol.t list -> unit

--- a/asmcomp/import_approx.ml
+++ b/asmcomp/import_approx.ml
@@ -55,6 +55,7 @@ let import_set_of_closures =
   in
   let aux set_of_closures_id =
     let ex_info = Compilenv.approx_env () in
+    let root_symbol = Compilenv.current_unit_symbol () in
     let function_declarations =
       try
         Set_of_closures_id.Map.find set_of_closures_id
@@ -63,7 +64,7 @@ let import_set_of_closures =
         Misc.fatal_errorf "[functions] does not map set of closures ID %a. \
             ex_info = %a"
           Set_of_closures_id.print set_of_closures_id
-          Export_info.print_all ex_info
+          Export_info.print_all (ex_info, [root_symbol])
     in
     import_function_declarations function_declarations
   in


### PR DESCRIPTION
- Fix printing of export_info MPR#7294

The printing function now requires a list of root symbols
- Add an option to hide some information in objinfo
